### PR TITLE
Update minDelayTarget's minimum value to 1

### DIFF
--- a/doc_source/sns-message-delivery-retries.md
+++ b/doc_source/sns-message-delivery-retries.md
@@ -71,7 +71,7 @@ The delivery policy is composed of a retry policy and a throttle policy\. In tot
 
 | Policy  | Description | Constraint | 
 | --- | --- | --- | 
-| minDelayTarget | The minimum delay for a retry\.**Unit:** Seconds | 0 to maximum delay**Default:** 20 | 
+| minDelayTarget | The minimum delay for a retry\.**Unit:** Seconds | 1 to maximum delay**Default:** 20 | 
 | maxDelayTarget | The maximum delay for a retry\.**Unit:** Seconds | Minimum delay to 3,600**Default:** 20 | 
 | numRetries | The total number of retries, including immediate, pre\-backoff, backoff, and post\-backoff retries\. | 0 to 100**Default:** 3 | 
 | numNoDelayRetries | The number of retries to be done immediately, with no delay between them\. | 0 or greater**Default:** 0 | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When I try to use 

```
healthyRetryPolicy:
    numRetries: 0
    minDelayTarget: 0
    maxDelayTarget: 0
    numMinDelayRetries: 0
    numMaxDelayRetries: 0
    numNoDelayRetries: 0
    backoffFunction: exponential
```

through CloudFormation, it reports this error 

```
Invalid parameter: Attributes Reason: DeliveryPolicy: healthyRetryPolicy.minDelayTarget must be greater than or equal to 1 (Service: AmazonSNS; Status Code: 400; Error Code: InvalidParameter;
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
