### PR TITLE
Include total maximum retry time limit for HTTP/S

### DIFF
--- a/doc_source/sns-message-delivery-retries.md
+++ b/doc_source/sns-message-delivery-retries.md
@@ -87,6 +87,8 @@ The delivery policy is composed of a retry policy and a throttle policy\. In tot
 | backoffFunction | The model for backoff between retries\.  |  One of four options: [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/sns/latest/dg/sns-message-delivery-retries.html) **Default:** linear  | 
 | maxReceivesPerSecond  | The maximum number of deliveries per second, per subscription\. | 1 or greater**Default:** No throttling | 
 
+Please note that the total policy retry time for a HTTP/S endpoint cannot be greater than 3600 seconds. This is a hard limit and cannot be increased.
+
 Amazon SNS uses the following formula to calculate the number of retries in the backoff phase:
 
 ```


### PR DESCRIPTION


*Issue #, if available:*

Currently, in the documentation we do not specify the total retry time limit for http/s susbcription protocol, even though the console throws error if the configured policy time goes beyond this limit. 

*Description of changes:*

We have customers reaching out about the maximum retry time for HTTP/S endpoint and if it can be increased. Including this info in the documentation will benefit a lot of the customers and save them time from contacting support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
