### PR TITLE
Add numberOfMessageParts in SMS delivery logs

### DIFF
--- a/doc_source/sms_stats_cloudwatch.md
+++ b/doc_source/sms_stats_cloudwatch.md
@@ -62,6 +62,7 @@ The delivery status log for a successful SMS delivery will resemble the followin
     "delivery": {
         "phoneCarrier": "My Phone Carrier",
         "mnc": 270,
+        "numberOfMessageParts": 1,
         "destination": "+1XXX5550100",
         "priceInUSD": 0.00645,
         "smsType": "Transactional",
@@ -86,6 +87,7 @@ The delivery status log for a failed SMS delivery will resemble the following ex
     },
     "delivery": {
         "mnc": 0,
+        "numberOfMessageParts": 1,
         "destination": "+1XXX5550100",
         "priceInUSD": 0.00645,
         "smsType": "Transactional",


### PR DESCRIPTION
*Description of changes:* SNS supports adding total message part of each message in the user's SMS delivery logs, which are missing on the public docs. This is helpful when checking why a particular message costed more than others if they were separated into more than one parts.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
