### PR TITLE
Incorrect policy condition for the description of the scenario?

### DIFF
--- a/doc_source/sns-access-policy-use-cases.md
+++ b/doc_source/sns-access-policy-use-cases.md
@@ -245,7 +245,7 @@ In this case, the topic in account 444455556666 is allowed to publish only from 
     "Action": "SNS:Publish",
     "Resource": "arn:aws:sns:us-east-2:444455556666:MyTopic",
     "Condition": {
-      "StringNotEquals": {
+      "StringEquals": {
         "aws:sourceVpce": "vpce-1ab2c34d"
       }
     }


### PR DESCRIPTION
The scenario states:

> the topic in account 444455556666 is allowed to publish only from the VPC endpoint with the ID `vpce-1ab2c34d`\

However, the condition in the policy is using a `StringNotEquals` for that vpc endpoint id which would have the inverse effect?

*Issue #, if available:*

*Description of changes:*

Change `StringNotEquals` to `StringEquals`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
