### PR TITLE
Fix JSON Formatting in Example Code

### DIFF
--- a/doc_source/sns-send-custom-platform-specific-payloads-mobile-devices.md
+++ b/doc_source/sns-send-custom-platform-specific-payloads-mobile-devices.md
@@ -93,7 +93,7 @@ The following is an example raw configuration object\.
 
 ```
 {
-  "APNS": "{\"aps\":{\"content-available\":1},\"Foo1\":\"\Bar\",\"Foo2\":123}"
+  "APNS": "{\"aps\":{\"content-available\":1},\"Foo1\":\"Bar\",\"Foo2\":123}"
 }
 ```
 


### PR DESCRIPTION
*Description of changes:*

Removed an extra `\` so the line for the example code is proper JSON format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
