### PR TITLE
Update sns-key-management.md with "EC2 Image Builder" related service

### DIFF
--- a/doc_source/sns-key-management.md
+++ b/doc_source/sns-key-management.md
@@ -120,6 +120,7 @@ Some Amazon SNS event sources require you to provide an IAM role \(rather than t
 [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/notifications-for-AWS-Config.html)
 [AWS Elastic Beanstalk](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.sns.html)
 [AWS IoT](https://docs.aws.amazon.com/iot/latest/developerguide/iot-sns-rule.html)
+[EC2 Image Builder](https://docs.aws.amazon.com/imagebuilder/latest/userguide/manage-infra-config.html)
 
 1. [Enable SSE for your topic](sns-enable-encryption-for-topic.md) using your CMK\.
 


### PR DESCRIPTION
*Description of changes:*
* Add reference to `EC2 Image Builder` service within the `compatibility-with-aws-services` section. EC2 Image Builder requires the service-linked role [AWSServiceRoleForImageBuilder](https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-service-linked-role.html) to be added into key policy instead of the service

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
