### PR TITLE
Correct the description for the steps

### DIFF
--- a/doc_source/sns-mobile-application-as-subscriber.md
+++ b/doc_source/sns-mobile-application-as-subscriber.md
@@ -33,9 +33,9 @@ Push notification services, such as APNs and FCM, maintain a connection with eac
 
 1. [Obtain the credentials and device token](sns-prerequisites-for-mobile-push-notifications.md) for the mobile platforms that you want to support\.
 
-1. Use the credentials to create a platform application object \(`PlatformApplicationArn`\) using Amazon SNS\. For more information, see [Creating a platform endpoint](mobile-platform-endpoint.md)\.
+1. Use the credentials to create a platform application object \(`PlatformApplicationArn`\) using Amazon SNS\. For more information, see [Creating a platform application](mobile-push-send-register.md)\.
 
-1. Use the returned credentials to request a device token for your mobile app and device from the mobile platforms\. The token you receive represents your mobile app and device\.
+1. Use the returned credentials to request a device token for your mobile app and device from the push notification service\. The token you receive represents your mobile app and device\.
 
 1. Use the device token and the `PlatformApplicationArn` to create a platform endpoint object \(`EndpointArn`\) using Amazon SNS\. For more information, see [Creating a platform endpoint](mobile-platform-endpoint.md)\.
 


### PR DESCRIPTION
*Issue #, if available:*
The description in the section "User notification process overview" is incorrect and causes confusion.

*Description of changes:*
- Correct the link in step 2 to the document for creating the platform application (https://docs.aws.amazon.com/sns/latest/dg/mobile-push-send-register.html)
- Correct the description in step 3, it should mention notification services instead of mobile platforms to be precise.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
